### PR TITLE
japanese

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -24,7 +24,7 @@
           <%= image_tag("no_image.png")%>
         <% end %>
         <%= event.contents %>
-        <p class="date"><%= event.date %></p>
+        <p class="date"><%= event.date.strftime("%Y年%m月%d日") %></p>
       </p>
     </div><!--/.col-xs-4.col-lg-4-->
   <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,6 +12,6 @@
     </div>
 <!-- /container--></div>
 <div class="container">
-  <p class="date"><%= @event.date %></p>
+  <p class="date"><%= @event.date.strftime("%Y年%m月%d日") %></p>
   <p><%= @event.contents %></p>
 <!-- container --></div>


### PR DESCRIPTION
dateをただ引用すると、表示フォーマットがUTCだったため、日本語表記に変更。
イカを参照。
http://ruby-rails.hatenadiary.com/entry/20141226/1419600679